### PR TITLE
Update Python Alpine container to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-FROM python:3.11-alpine3.19 AS build
+FROM python:3.11-alpine3.21 AS build
 
 # Build-time flags
 ARG WITH_PLUGINS=true


### PR DESCRIPTION
Upgrading the python3.11 container to latest available Alpine version.